### PR TITLE
CB-164

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The following features are currently supported:
   - [x] Scaffold basic OWA folder structure and files
   - [x] Production build with [Webpack](https://webpack.github.io/)
   - [x] Local deploy with Webpack
+  - [x] Toggle OWA version number in filename
   - [x] Package management with [npm](http://npmjs.com/)
   - [x] Live reload, interaction sync and more with [Browsersync](https://www.browsersync.io/)
 
@@ -56,6 +57,13 @@ entry: {
   ]
 },
 ````
+
+To include OWA version number in package:
+````
+const packageIncludesVersionNumber = true;
+````
+In webpack.config.js
+
 
 Any files that you add manually must be added in the `app` directory.
 

--- a/app/templates/webpack.config.js
+++ b/app/templates/webpack.config.js
@@ -42,6 +42,8 @@ let outputFile = `.bundle`;
 let vendorOutputFile;
 let outputPath;
 
+const packageIncludesVersionNumber = true;
+
 var configJson;
 let appEntryPoint;
 let localOwaFolder;
@@ -101,7 +103,8 @@ if (env === 'production') {
 	  plugins.push(new WebpackOnBuildPlugin(function(stats){
       //create zip file
       var archiver = require('archiver');
-			var output = fs.createWriteStream(THIS_APP_ID+'_'+THIS_APP_VER+'.zip');
+			const outputFilename = (packageIncludesVersionNumber) ? THIS_APP_ID+'_'+THIS_APP_VER+'.zip' : THIS_APP_ID+'_'+'.zip';
+			var output = fs.createWriteStream(outputFilename);
 			var archive = archiver('zip');
 
 			output.on('close', function () {

--- a/app/templates/webpack.config.js
+++ b/app/templates/webpack.config.js
@@ -27,7 +27,13 @@ const WebpackOnBuildPlugin = require('on-build-webpack');
 
 const nodeModulesDir = path.resolve(__dirname, '../node_modules');
 
+require.extensions['.webapp'] = function (module, filename) {
+  module.exports = fs.readFileSync(filename, 'utf8');
+};
+const manifest = require('./app/manifest.webapp');
+
 const THIS_APP_ID = '<%= appId %>';
+const THIS_APP_VER = JSON.parse(manifest).version;
 
 var plugins = [];
 const nodeModules = {};
@@ -95,7 +101,7 @@ if (env === 'production') {
 	  plugins.push(new WebpackOnBuildPlugin(function(stats){
       //create zip file
       var archiver = require('archiver');
-			var output = fs.createWriteStream(THIS_APP_ID+'.zip');
+			var output = fs.createWriteStream(THIS_APP_ID+'_'+THIS_APP_VER+'.zip');
 			var archive = archiver('zip');
 
 			output.on('close', function () {

--- a/generator_system_tests.md
+++ b/generator_system_tests.md
@@ -1,0 +1,143 @@
+# System Tests: Patient-Friendly Report Generator
+
+<br>
+These system tests deal with OWAs generated with AngularJS.
+<br>
+
+## Prerequisites
+*These will necessary before any of the following system tests can be performed.*
+
+1. OpenMRS and MySQL server must be installed.
+2. The `openmrs-module-owa` package must be present.
+3. The `generator-openmrs-owa` package must be present.
+4. yo generator must be installed.
+5. Chrome must be installed for Karma tests.
+6. node.js must be installed.
+7. Any other relevant OpenMRS OWA dependencies should be set up as needed.
+
+<br>
+
+## System Tests
+
+### T - 01: Bundling With Version Number
+1. Open the `webpack.config.js` file within the `generator-openmrs-owa` package (typical filepath might be `/Users/username/openmrs/generator-openmrs-owa/app/templates/webpack.config.js`).   Seek out a line within this file: 
+> const packageIncludesVersionNumber = true;
+
+2. Make sure this boolean value is `true` before moving forward. This will tell the generator to include the OWA version number in the generated OWA package.
+3. Create a new directory in a location of your choosing (ex: a `test_owa` directory within an `openmrs` directory in your home directory works).  This directory will store all the OWA files.  Using a bash terminal, enter this folder (ex: `cd ~/openmrs-filepath/test_owa`).
+4. Run `yo` to show yo generator option. You should be greeted with some yo generator prompts:
+> ? 'Allo Ethan! What would you like to do? (Use arrow keys) <br>
+> &nbsp;&nbsp; Run a generator <br>
+> ❯ @openmrs/openmrs Owa <br>
+> &nbsp;&nbsp; ────────────── <br>
+> &nbsp;&nbsp; Update your generators <br>
+> &nbsp;&nbsp; Install a generator <br>
+> &nbsp;&nbsp; Find some help <br>
+> &nbsp;&nbsp; Get me out of here! <br> 
+> (Move up and down to reveal more choices)
+5. Select the `@openmrs/openmrs Owa` generator option to begin OWA generation.
+6. Enter the OWA information.
+	* What is your app name? Any name will be fine. (ex: `my test owa`).
+	* What is your app description? Any description will be fine. (ex: `Medical Report OWA`).
+	* What libraries would you like to include? Make sure to select `AngularJS`.
+	* What type of server are you running locally? Make sure to select `SDK`.
+	* What URL will your app be served from? Hit **Enter** to accept the default (ex: `http://localhost:8080/openmrs/owa/mytestowa/index.html`).
+	* What is the path of your local Open Web Apps directory? Hit **Enter** to accept the default (ex: `/Users/username/openmrs/openmrs-platform/owa`).  *NOTE: Your specific path may need to be manually entered or chnaged if you have configured your OpenMRS directories differently.*
+	* What is your GitHub username? Enter your GitHub username.
+	* What will the GitHub repo URL be? Enter the GitHub URL. You can also just hit **Enter** to accept the defult if you will not be using GitHub (ex: `https://github.com/username/openmrs-owa-mytestowa`).
+
+7. After entering this information, yo should run a number of installs and commands to set up your OWA. This will show a numbeer of lines that look like `create {file-name}`, followed by a number of `npm` commands. Finally, you should recieve a success message and be returned to your OWA directory.
+>  Bye from us! <br>
+>  Chat soon. <br>
+>  Yeoman team <br>
+>  http://yeoman.io
+8. Your (previously empty) OWA directory should now be populated with a number of files. You can run `ls` to verify the files are akin to...
+> LICENSE <br>
+> README.md <br>
+> app <br>
+> karma.conf.js <br>
+> node_modules <br>
+> package-lock.json <br>
+> package.json <br>
+> test <br>
+> webpack.config.js
+9. Open the `package.json` file in your `test_owa` directory and remove the raised carrot (^) from its placement before any version number that is an angular dependency (typically there are roughly 8 to remove). Save your changes.
+> "angular-ui-router": "^0.3.0",
+10. Remove the line starting with `.config` from the `home.js` file in the OWA directory (typical filepath might be `/Users/username/openmrs/test_owa/app/js/home/home.js`).
+> .config(['$qProvider', function ($qProvider) { <br>
+> &nbsp;&nbsp; $qProvider.errorOnUnhandledRejections(false); <br>
+> }])
+11. Run `npm install` in the OWA directory (ex: `test_owa`).
+12. Run `npm run build:prod` the OWA directory (ex: `test_owa`) to generate your OWA zip file.
+13. Run `mvn clean install` in the `openmrs-module-owa` directory (typical filepath might be `/Users/username/openmrs/openmrs-module-owa`).
+14. Locate the OWA snapshot omod file in the `openmrs-module-owa` directory (ex: `/Users/username/openmrs/openmrs-module-owa/omod/target/owa-1.11.0-SNAPSHOT.omod`).
+15. Move this omod file to the modules directory of your openmrs server directory (typical filepath might be `/Users/username/openmrs/server-name/modules`).
+16. Start your OpenMRS server (start MySQL server and run `mvn openmrs-sdk:run`).
+17. Log in to OpenMRS and import your newly-packaged OWA zip (ex: `/Users/username/openmrs/test_owa/mytestowa_0.1.0.zip`).
+18. Confirm that the zip file contains the version number (ex: `mytestowa_0.1.0.zip`).
+19. Open the OWA in OpenMRS and check that the URL does not include the version number (ex: `http://localhost:8080/openmrs/owa/mytestowa/index.html#/`).
+
+
+### T - 02: Bundling Without Version Number
+1. Open the `webpack.config.js` file within the `generator-openmrs-owa` package (typical filepath might be `/Users/username/openmrs/generator-openmrs-owa/app/templates/webpack.config.js`).   Seek out a line within this file: 
+> const packageIncludesVersionNumber = true;
+
+2. Make sure this boolean value is `false` before moving forward. This will tell the generator to include the OWA version number in the generated OWA package.
+3. Create a new directory in a location of your choosing (ex: a `test_owa` directory within an `openmrs` directory in your home directory works).  This directory will store all the OWA files.  Using a bash terminal, enter this folder (ex: `cd ~/openmrs-filepath/test_owa`).
+4. Run `yo` to show yo generator option. You should be greeted with some yo generator prompts:
+> ? 'Allo Ethan! What would you like to do? (Use arrow keys) <br>
+> &nbsp;&nbsp; Run a generator <br>
+> ❯ @openmrs/openmrs Owa <br>
+> &nbsp;&nbsp; ────────────── <br>
+> &nbsp;&nbsp; Update your generators <br>
+> &nbsp;&nbsp; Install a generator <br>
+> &nbsp;&nbsp; Find some help <br>
+> &nbsp;&nbsp; Get me out of here! <br> 
+> (Move up and down to reveal more choices)
+5. Select the `@openmrs/openmrs Owa` generator option to begin OWA generation.
+6. Enter the OWA information.
+	* What is your app name? Any name will be fine. (ex: `my test owa`).
+	* What is your app description? Any description will be fine. (ex: `Patient Drug Report OWA`).
+	* What libraries would you like to include? Make sure to select `AngularJS`.
+	* What type of server are you running locally? Make sure to select `SDK`.
+	* What URL will your app be served from? Hit **Enter** to accept the default (ex: `http://localhost:8080/openmrs/owa/mytestowa/index.html`).
+	* What is the path of your local Open Web Apps directory? Hit **Enter** to accept the default (ex: `/Users/username/openmrs/openmrs-platform/owa`).  *NOTE: Your specific path may need to be manually entered or chnaged if you have configured your OpenMRS directories differently.*
+	* What is your GitHub username? Enter your GitHub username.
+	* What will the GitHub repo URL be? Enter the GitHub URL. You can also just hit **Enter** to accept the defult if you will not be using GitHub (ex: `https://github.com/username/openmrs-owa-mytestowa`).
+
+7. After entering this information, yo should run a number of installs and commands to set up your OWA. This will show a numbeer of lines that look like `create {file-name}`, followed by a number of `npm` commands. Finally, you should recieve a success message and be returned to your OWA directory.
+>  Bye from us! <br>
+>  Chat soon. <br>
+>  Yeoman team <br>
+>  http://yeoman.io
+8. Your (previously empty) OWA directory should now be populated with a number of files. You can run `ls` to verify the files are akin to...
+> LICENSE <br>
+> README.md <br>
+> app <br>
+> karma.conf.js <br>
+> node_modules <br>
+> package-lock.json <br>
+> package.json <br>
+> test <br>
+> webpack.config.js
+9. Open the `package.json` file in your `test_owa` directory and remove the raised carrot (^) from its placement before any version number that is an angular dependency (typically there are roughly 8 to remove). Save your changes.
+> "angular-ui-router": "^0.3.0",
+10. Remove the line starting with `.config` from the `home.js` file in the OWA directory (typical filepath might be `/Users/username/openmrs/test_owa/app/js/home/home.js`).
+> .config(['$qProvider', function ($qProvider) { <br>
+> &nbsp;&nbsp; $qProvider.errorOnUnhandledRejections(false); <br>
+> }])
+11. Run `npm install` in the OWA directory (ex: `test_owa`).
+12. Run `npm run build:prod` the OWA directory (ex: `test_owa`) to generate your OWA zip file.
+13. Run `mvn clean install` in the `openmrs-module-owa` directory (typical filepath might be `/Users/username/openmrs/openmrs-module-owa`).
+14. Locate the OWA snapshot omod file in the `openmrs-module-owa` directory (ex: `/Users/username/openmrs/openmrs-module-owa/omod/target/owa-1.11.0-SNAPSHOT.omod`).
+15. Move this omod file to the modules directory of your openmrs server directory (typical filepath might be `/Users/username/openmrs/server-name/modules`).
+16. Start your OpenMRS server (start MySQL server and run `mvn openmrs-sdk:run`).
+17. Log in to OpenMRS and import your newly-packaged OWA zip (ex: `/Users/username/openmrs/test_owa/mytestowa.zip`).
+18. Confirm that the zip file does not contain the version number (ex: `mytestowa.zip`).
+19. Open the OWA in OpenMRS and check that the URL does not include the version number (ex: `http://localhost:8080/openmrs/owa/mytestowa/index.html#/`).
+
+
+## System Test Results
+*Enter notes and results here:*
+
+<br>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@openmrs/generator-openmrs-owa",
+  "name": "@openmrs/generator-openmrs-owa-test",
   "version": "0.7.1",
   "description": "Scaffold OpenMRS Open Web Apps.",
   "license": "MPL-2.0",


### PR DESCRIPTION
Newly generated OWA's now contain version number when bundled. 

- Edited yeoman generator to create webpack.config.js that adds version number to bundled OWA.
- Boolean to toggle version number when packaged.
- This PR is dependent on another PR in `openmrs-module-owa` by the same name, `CB-164`, which is used to remove the version number from the OWA's URL when uploaded to OpenMRS.