### PR TITLE
Generator generates webpack.config.js that adds version number to bun…

### DIFF
--- a/app/templates/webpack.config.js
+++ b/app/templates/webpack.config.js
@@ -27,7 +27,13 @@ const WebpackOnBuildPlugin = require('on-build-webpack');
 
 const nodeModulesDir = path.resolve(__dirname, '../node_modules');
 
+require.extensions['.webapp'] = function (module, filename) {
+  module.exports = fs.readFileSync(filename, 'utf8');
+};
+const manifest = require('./app/manifest.webapp');
+
 const THIS_APP_ID = '<%= appId %>';
+const THIS_APP_VER = JSON.parse(manifest).version;
 
 var plugins = [];
 const nodeModules = {};
@@ -35,6 +41,8 @@ const nodeModules = {};
 let outputFile = `.bundle`;
 let vendorOutputFile;
 let outputPath;
+
+const packageIncludesVersionNumber = true;
 
 var configJson;
 let appEntryPoint;
@@ -95,7 +103,8 @@ if (env === 'production') {
 	  plugins.push(new WebpackOnBuildPlugin(function(stats){
       //create zip file
       var archiver = require('archiver');
-			var output = fs.createWriteStream(THIS_APP_ID+'.zip');
+			const outputFilename = (packageIncludesVersionNumber) ? THIS_APP_ID+'_'+THIS_APP_VER+'.zip' : THIS_APP_ID+'_'+'.zip';
+			var output = fs.createWriteStream(outputFilename);
 			var archive = archiver('zip');
 
 			output.on('close', function () {


### PR DESCRIPTION
CB-164 Adding version number to bundled OWA file name
<!--- Add a pull request title above in this format -->
<!--- real example: 'TRUNK-5111 Replace use of deprecated isVoided' -->
<!--- 'TRUNK-JiraIssueNumber JiraIssueTitle' -->
## Description of what I changed

yeoman generator now generates a webpack.config.js file that appends the version number to an OWA when bundled. Can be turned on and off with boolean `packageIncludesVersionNumber`. 

Another PR in `openmrs-module-owa` by the same name (CB-164) removes the version number from the OWA URL. 

<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->


## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it -->
<!--- Just add the issue number at the end: -->
see https://issues.openmrs.org/browse/CB-164
# Checklist:
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My pull request only contains **ONE single commit**
(the number above, next to the 'Commits' tab is 1).

- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

- [x] All new and existing **tests passed**.

- [x] My pull request is **based on the latest changes** of the master branch.